### PR TITLE
Updating from 1.0.6 to 1.0.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 	loader_version=0.14.22
 
 # Mod Properties
-	mod_version = 1.0.6
+	mod_version = 1.0.7
 	maven_group = com.example
 	archives_base_name = building_dimension
 

--- a/src/main/java/net/fabricmc/BuildingDimension/BuildingDimension.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/BuildingDimension.java
@@ -54,6 +54,7 @@ public class BuildingDimension implements ModInitializer {
 				OVERWORLD
 		);
 	}
+
 	private void registerCommands(@NotNull CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess registryAccess, CommandManager.RegistrationEnvironment environment) {
 		dispatcher
 				.register(literal("creative")

--- a/src/main/java/net/fabricmc/BuildingDimension/Commands/SwitchDimension.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Commands/SwitchDimension.java
@@ -56,6 +56,7 @@ public class SwitchDimension {
             WORLD_DATA.saveExperience(player);
             WORLD_DATA.saveEffects(player);
             WORLD_DATA.saveAdvancements(player);
+            WORLD_DATA.saveGameMode(player);
             target = new TeleportTarget(
                     player.getPos(),
                     player.getVelocity(),
@@ -70,7 +71,7 @@ public class SwitchDimension {
             BuildingDimension.log("Player : " + player.getName().getString() + " is switching to survival dimension");
 
             world = context.getSource().getServer().getWorld(World.OVERWORLD);
-            gameMode = GameMode.SURVIVAL;
+            gameMode = WORLD_DATA.loadGameMode(player);
 
             WORLD_DATA.saveInventory(context.getSource().getWorld(), player);
 

--- a/src/main/java/net/fabricmc/BuildingDimension/Commands/SwitchDimension.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Commands/SwitchDimension.java
@@ -2,6 +2,7 @@ package net.fabricmc.BuildingDimension.Commands;
 
 import com.mojang.brigadier.context.CommandContext;
 import net.fabricmc.BuildingDimension.BuildingDimension;
+import net.fabricmc.BuildingDimension.Configs;
 import net.fabricmc.BuildingDimension.World.SavedData;
 import net.fabricmc.fabric.api.dimension.v1.FabricDimensions;
 import net.minecraft.inventory.EnderChestInventory;
@@ -18,10 +19,17 @@ import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 public class SwitchDimension {
 
     private static final RegistryKey<World> OVERWORLD_WORLD_KEY = BuildingDimension.OVERWORLD_WORLD_KEY;
     private static SavedData WORLD_DATA = BuildingDimension.WORLD_DATA;
+
+    private static final Map<UUID, Long> last_switch = new HashMap<>();
 
     public static int switch_dim(@NotNull CommandContext<ServerCommandSource> context) {
         Identifier current_dim = context.getSource().getWorld().getRegistryKey().getValue();
@@ -36,6 +44,18 @@ public class SwitchDimension {
             return -1;
         }
 
+        if (last_switch.containsKey(player.getUuid())) {
+            long last_switch_time = last_switch.get(player.getUuid());
+            long current_time = new Date().getTime();
+
+            if (current_time - last_switch_time < 5000) {
+                context.getSource().sendMessage(Text.literal("You must wait 5 second between dimension switches"));
+                return -1;
+            }
+        } else {
+            last_switch.put(player.getUuid(), new Date().getTime());
+        }
+
         if (WORLD_DATA == null) {
             MinecraftServer server = context.getSource().getServer();
 
@@ -47,8 +67,18 @@ public class SwitchDimension {
 
             BuildingDimension.log("Player : " + player.getName().getString() + " is switching to creative dimension");
 
+            if (Configs.ONLY_OP && !player.hasPermissionLevel(4) && !Configs.NON_OPS_SPECTATOR) {
+                context.getSource().sendMessage(Text.literal("You must be an operator to use this command"));
+                return -1;
+            }
+
             world = context.getSource().getServer().getWorld(OVERWORLD_WORLD_KEY);
-            gameMode = GameMode.CREATIVE;
+            gameMode =
+                    context.getSource().getPlayer().hasPermissionLevel(4) ?
+                            GameMode.CREATIVE :
+                            Configs.ONLY_OP && Configs.NON_OPS_SPECTATOR ?
+                                    GameMode.SPECTATOR :
+                                    GameMode.CREATIVE;
 
             WORLD_DATA.savePosition(player);
             WORLD_DATA.saveInventory(context.getSource().getWorld(), player);

--- a/src/main/java/net/fabricmc/BuildingDimension/Commands/SyncDimension.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Commands/SyncDimension.java
@@ -23,35 +23,31 @@ public class SyncDimension {
     public static final RegistryKey<World> CREATIVE_OVERWORLD_KEY = BuildingDimension.OVERWORLD_WORLD_KEY;
 
     public static int sync_chunk_one(CommandContext<ServerCommandSource> context) {
-
-        if ( server == null ) server = Objects.requireNonNull(context.getSource().getServer());
-
-        BuildingDimension.log("Syncing chunk at " + context.getSource().getPosition().toString());
-
-        int chunkX = (int) Math.floor(context.getSource().getPosition().x / 16);
-        int chunkZ = (int) Math.floor(context.getSource().getPosition().z / 16);
-
-        Chunk chunk = context.getSource().getWorld().getChunk(chunkX, chunkZ);
-        chunksToSync.add(chunk);
-
-        needsSync = true;
-
-        return 0;
+        return sync(context, 1);
     }
 
     public static int sync_chunk_radius(CommandContext<ServerCommandSource> context) {
+        return sync(context, context.getArgument("radius", Integer.class));
+    }
 
+    private static int sync(CommandContext<ServerCommandSource> context, int radius) {
         if ( server == null ) server = Objects.requireNonNull(context.getSource().getServer());
-        int radius = context.getArgument("radius", Integer.class);
 
         BuildingDimension.log("Syncing chunks in radius " + radius + " around " + context.getSource().getPosition().toString());
+
+        World world = context.getSource().getServer().getWorld(World.OVERWORLD);
+
+        if (world == null) {
+            BuildingDimension.log("Failed to sync chunks: world is null when getting chunks");
+            return -1;
+        }
 
         for (int x = -radius; x <= radius; x++) {
             for (int z = -radius; z <= radius; z++) {
                 int chunkX = (int) Math.floor(context.getSource().getPosition().x / 16) + x;
                 int chunkZ = (int) Math.floor(context.getSource().getPosition().z / 16) + z;
 
-                Chunk chunk = context.getSource().getWorld().getChunk(chunkX, chunkZ);
+                Chunk chunk = world.getChunk(chunkX, chunkZ);
                 chunksToSync.add(chunk);
             }
         }

--- a/src/main/java/net/fabricmc/BuildingDimension/Commands/Teleport.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Commands/Teleport.java
@@ -7,12 +7,18 @@ import net.minecraft.command.EntitySelector;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+
 public class Teleport {
 
     public static int teleport(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
 
         ServerPlayerEntity player = source.getPlayer();
+
+        if ( player == null ) {
+            source.sendError(Text.literal("You must be a player to use this command"));
+            return 0;
+        }
 
         if ( !player.getWorld().getRegistryKey().equals(BuildingDimension.OVERWORLD_WORLD_KEY) ) {
             player.sendMessage(Text.literal("You must be in the creative world to use this command"));

--- a/src/main/java/net/fabricmc/BuildingDimension/Configs.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Configs.java
@@ -2,10 +2,13 @@ package net.fabricmc.BuildingDimension;
 
 import com.moandjiezana.toml.Toml;
 import net.fabricmc.loader.api.FabricLoader;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Objects;
+import java.util.function.Function;
 
 public class Configs {
 
@@ -14,6 +17,8 @@ public class Configs {
     private static final File CONFIG_FILE = new File(CONFIG_FILE_PATH);
 
     public static int MAX_RADIUS = 8;
+    public static boolean ONLY_OP = false;
+    public static boolean NON_OPS_SPECTATOR = true;
     public static boolean OP_SYNC = true;
 
     public static void load() {
@@ -24,45 +29,44 @@ public class Configs {
 
         Toml toml = new Toml().read(CONFIG_FILE);
 
-        if (toml.contains("max_radius")) {
-            try {
-                MAX_RADIUS = Integer.max(1, Integer.min(32, toml.getLong("max_radius").intValue()));
-            } catch (Exception e) {
-                BuildingDimension.LOGGER.error("Invalid max_radius value! (1 ~ 32)");
-            }
-        }
-        if (toml.contains("op_sync")) {
-            try {
-                OP_SYNC = toml.getBoolean("op_sync");
-            } catch (Exception e) {
-                BuildingDimension.LOGGER.error("Invalid op_sync value! (true or false)");
-            }
-        }
+        check_config(toml, "max_radius", (config_value) -> {
+            MAX_RADIUS = Integer.max(1, Integer.min(32, toml.getLong(config_value).intValue()));
+            return true;
+        });
+        check_config(toml, "only_ops", (config_value) -> {
+            ONLY_OP = toml.getBoolean(config_value);
+            return true;
+        });
+        check_config(toml, "non_ops_spectators", (config_value) -> {
+            NON_OPS_SPECTATOR = toml.getBoolean(config_value);
+            return true;
+        });
+        check_config(toml, "op_sync", (config_value) -> {
+            OP_SYNC = toml.getBoolean(config_value);
+            return true;
+        });
     }
 
     private static void generate() {
         try {
-            if (!CONFIG_FILE.exists()) {
-                if (!CONFIG_FILE.createNewFile()) {
-                    BuildingDimension.LOGGER.error("Failed to create config file!");
-                    return;
-                }
-            }
-
-            FileWriter writer = new FileWriter(CONFIG_FILE);
-
-            writer.write("# Max radius when syncing chunks (1 ~ 32)\n");
-            writer.write("# default : 8\n");
-            writer.write("max_radius = 8\n\n");
-
-            writer.write("# Whether only OPs can sync chunks (true : only OPs can sync, false : everyone can sync)\n");
-            writer.write("# default : true\n");
-            writer.write("op_sync = true\n\n");
-
-            writer.close();
+            Files.copy(
+                    Objects.requireNonNull(BuildingDimension.class.getResourceAsStream("/assets/config/building_dimension.toml")),
+                    CONFIG_FILE.toPath()
+            );
 
         } catch (IOException e) {
             BuildingDimension.LOGGER.error("Failed to generate config file!");
+        }
+    }
+
+    private static void check_config (@NotNull Toml toml, String config_value, Function<String, Boolean> apply) {
+        if (toml.contains(config_value)) {
+            try {
+                apply.apply(config_value);
+
+            } catch (Exception e) {
+                BuildingDimension.LOGGER.error("Failed to load config value: " + config_value);
+            }
         }
     }
 }

--- a/src/main/java/net/fabricmc/BuildingDimension/Configs.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Configs.java
@@ -52,9 +52,11 @@ public class Configs {
             FileWriter writer = new FileWriter(CONFIG_FILE);
 
             writer.write("# Max radius when syncing chunks (1 ~ 32)\n");
+            writer.write("# default : 8\n");
             writer.write("max_radius = 8\n\n");
 
             writer.write("# Whether only OPs can sync chunks (true : only OPs can sync, false : everyone can sync)\n");
+            writer.write("# default : true\n");
             writer.write("op_sync = true\n\n");
 
             writer.close();

--- a/src/main/java/net/fabricmc/BuildingDimension/Configs.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Configs.java
@@ -24,8 +24,20 @@ public class Configs {
 
         Toml toml = new Toml().read(CONFIG_FILE);
 
-        MAX_RADIUS = Integer.max(1, Integer.min(32, toml.getLong("max_radius").intValue()));
-        OP_SYNC = toml.getBoolean("op_sync");
+        if (toml.contains("max_radius")) {
+            try {
+                MAX_RADIUS = Integer.max(1, Integer.min(32, toml.getLong("max_radius").intValue()));
+            } catch (Exception e) {
+                BuildingDimension.LOGGER.error("Invalid max_radius value! (1 ~ 32)");
+            }
+        }
+        if (toml.contains("op_sync")) {
+            try {
+                OP_SYNC = toml.getBoolean("op_sync");
+            } catch (Exception e) {
+                BuildingDimension.LOGGER.error("Invalid op_sync value! (true or false)");
+            }
+        }
     }
 
     private static void generate() {

--- a/src/main/java/net/fabricmc/BuildingDimension/Events/SyncDimension.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/Events/SyncDimension.java
@@ -1,13 +1,18 @@
 package net.fabricmc.BuildingDimension.Events;
 
+import net.fabricmc.BuildingDimension.BuildingDimension;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.block.BlockState;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3i;
+import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.WorldChunk;
 import net.minecraft.world.chunk.light.LightingProvider;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -48,16 +53,23 @@ public class SyncDimension {
         });
     }
 
-    private static void syncChunk(WorldChunk chunk) {
+    private static void syncChunk(@NotNull WorldChunk chunk) {
         int ChunkX = chunk.getPos().x;
         int ChunkZ = chunk.getPos().z;
 
-        WorldChunk creative_chunk = server.getWorld(CREATIVE_OVERWORLD_KEY).getChunk(ChunkX, ChunkZ);
+        World creative_world = server.getWorld(CREATIVE_OVERWORLD_KEY);
+
+        if (creative_world == null) {
+            BuildingDimension.log("Unable to sync chunk " + ChunkX + ", " + ChunkZ + " because creative world is null");
+            return;
+        }
+
+        WorldChunk creative_chunk = creative_world.getChunk(ChunkX, ChunkZ);
         Set<Vec3i> posToProcess = new HashSet<>();
 
-        creative_chunk.forEachLightSource((pos, blockState) -> {
-            posToProcess.add(new Vec3i(pos.getX(), pos.getY(), pos.getZ()));
-        });
+        creative_chunk.forEachLightSource((pos, state) ->
+            posToProcess.add(new Vec3i(pos.getX(), pos.getY(), pos.getZ()))
+        );
 
         for (int y = -63; y < 320; y++) {
             for (int z = 0; z < 16; z++) {
@@ -67,7 +79,7 @@ public class SyncDimension {
                     BlockState creative_state = creative_chunk.getBlockState(pos);
 
                     if (state != creative_state) {
-                        posToProcess.add(new Vec3i(pos.getX(), pos.getY(), pos.getZ()));
+                        posToProcess.add(new Vec3i(pos.getX() + ChunkX * 16, pos.getY(), pos.getZ() + ChunkZ * 16));
                         creative_chunk.setBlockState(pos, state, false);
                     }
                 }
@@ -79,15 +91,33 @@ public class SyncDimension {
         needsProcessing = true;
     }
 
-    private static void postProcess(WorldChunk chunk) {
+    private static void postProcess(@NotNull WorldChunk chunk) {
         chunk.runPostProcessing();
 
-        LightingProvider lightingProvider = chunk.getWorld().getChunkManager().getLightingProvider();
+        World world = chunk.getWorld();
+
+        LightingProvider lightingProvider = world.getChunkManager().getLightingProvider();
 
         if (PosToProcess.containsKey(chunk.getPos())) {
-            PosToProcess.get(chunk.getPos()).forEach(pos -> lightingProvider.checkBlock(new BlockPos(pos.getX(), pos.getY(), pos.getZ())));
+            PosToProcess.get(chunk.getPos()).forEach(pos ->
+                lightingProvider.checkBlock(new BlockPos(pos.getX(), pos.getY(), pos.getZ()))
+            );
         }
 
-        chunk.forEachLightSource((pos, blockState) -> lightingProvider.checkBlock(pos));
+        // sending all block updates with light and block events
+        world.getPlayers().forEach(player -> {
+            if (player instanceof ServerPlayerEntity) {
+                int view_distance = server.getPlayerManager().getViewDistance();
+
+                if (Math.abs(player.getPos().x - chunk.getPos().getStartX()) > 16 * view_distance) return;
+                if (Math.abs(player.getPos().z - chunk.getPos().getStartZ()) > 16 * view_distance) return;
+
+                PosToProcess.get(chunk.getPos()).forEach(pos -> {
+                    BlockPos update_pos = new BlockPos(pos.getX(), pos.getY(), pos.getZ());
+                    ((ServerPlayerEntity) player).networkHandler.sendPacket(new BlockUpdateS2CPacket(chunk.getWorld(), update_pos));
+                });
+            }
+        }
+        );
     }
 }

--- a/src/main/java/net/fabricmc/BuildingDimension/World/SavedData.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/World/SavedData.java
@@ -15,10 +15,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.PersistentState;
-import net.minecraft.world.PersistentStateManager;
-import net.minecraft.world.TeleportTarget;
-import net.minecraft.world.World;
+import net.minecraft.world.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -39,6 +36,7 @@ public class SavedData extends PersistentState {
 
     private final Map<UUID, HashMap<Identifier, Set<String>>> advancements = new HashMap<>();
     private Map<Identifier, Advancement> advancementsList = null;
+    private final Map<UUID, GameMode> gameModes = new HashMap<>();
 
     @Override
     public NbtCompound writeNbt(@NotNull NbtCompound nbt) {
@@ -478,5 +476,21 @@ public class SavedData extends PersistentState {
                 }
             }
         }
+    }
+
+    public void saveGameMode(@NotNull ServerPlayerEntity player){
+        BuildingDimension.log("Loading game mode for " + player.getName().getString());
+
+        gameModes.put(player.getUuid(), player.interactionManager.getGameMode());
+    }
+
+    public GameMode loadGameMode(@NotNull ServerPlayerEntity player){
+        BuildingDimension.log("Loading game mode for " + player.getName().getString());
+
+        if (!gameModes.containsKey(player.getUuid())) {
+            gameModes.put(player.getUuid(), GameMode.SURVIVAL);
+        }
+
+        return gameModes.get(player.getUuid());
     }
 }

--- a/src/main/java/net/fabricmc/BuildingDimension/mixin/WorldEventS2CPacketMixin.java
+++ b/src/main/java/net/fabricmc/BuildingDimension/mixin/WorldEventS2CPacketMixin.java
@@ -1,0 +1,31 @@
+package net.fabricmc.BuildingDimension.mixin;
+
+import net.minecraft.network.packet.s2c.play.WorldEventS2CPacket;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+@Mixin(WorldEventS2CPacket.class)
+public class WorldEventS2CPacketMixin {
+
+    @Mutable
+    @Final
+    @Shadow
+    private int eventId;
+
+    @Inject(method = "<init>(ILnet/minecraft/util/math/BlockPos;IZ)V", at = @At("RETURN"))
+    private void init(int eventId, BlockPos pos, int data, boolean global, CallbackInfo ci) {
+        if (eventId == 1032) {
+            StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+            Arrays.stream(stackTraceElements)
+                    .filter(stackTraceElement -> stackTraceElement.toString().contains("BuildingDimension"))
+                    .findAny()
+                    .ifPresent(stackTraceElement -> this.eventId = 0);
+        }
+    }
+
+}

--- a/src/main/resources/assets/config/building_dimension.toml
+++ b/src/main/resources/assets/config/building_dimension.toml
@@ -1,0 +1,17 @@
+# Max radius when syncing chunks (1 ~ 32)
+# default : 8
+max_radius = 8
+
+# Whether only OPs can enter the building dimension (true : only OPs can enter, false : everyone can enter)
+# default : false
+only_ops = false
+
+# Can non OPs enter in spectator if only OPs can enter (true : non OPs enter in spectator, false : non OPs cannot enter)
+# the only_ops value must be true
+# default : true
+non_ops_spectators = true
+
+# Whether only OPs can sync chunks (true : only OPs can sync, false : everyone can sync)
+# default : true
+op_sync = true
+

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -5,9 +5,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "EndPortalBlockMixin",
-    "NetherPortalBlockMixin"
-  ],
-  "client": [
+    "NetherPortalBlockMixin",
+    "WorldEventS2CPacketMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Here is what's new in this version : 

Syncing a chunk is now possible from the creative dimension itself. Make sure you are not in a place that is going to have blocks later!

config file is copied from the mod instead of created, this makes the code clearer by not having the whole config file creation into it.

No sound will be played when teleporting to the creative dimension. This has been done pretty poorly and will need more work late but is Server side only, keeping the mod only server required.

now showing default values for the configs in the configuration file.

fix incorrect lighting pos-processing on block that were changed

now checking that the line is present before getting the value from the config file.

now preventing a crash when the value for a config is not the expected value (Double given when an Integer was expected) Those checks need to be improved to be more scalable.

Saving the Gamemode the player was before entering the building dimension and restoring it when coming back to the normal / overworld dimension.